### PR TITLE
Fix reactivity of sortable and virtual props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -53,7 +53,7 @@ const VirtualDragList = defineComponent({
 
     const sortableAttributes = computed(() => {
       return SortableAttrs.reduce((res, key) => {
-        res[key] = this[key];
+        res[key] = props[key];
         return res;
       }, {});
     });
@@ -131,29 +131,23 @@ const VirtualDragList = defineComponent({
       }
     );
 
-    watch(
-      () => virtualAttributes,
-      (newVal, oldVal) => {
-        if (!virtual) return;
-        for (let key in newVal) {
-          if (newVal[key] != oldVal[key]) {
-            virtual.option(key as any, newVal[key]);
-          }
+    watch(virtualAttributes, (newVal, oldVal) => {
+      if (!virtual) return;
+      for (let key in newVal) {
+        if (newVal[key] != oldVal[key]) {
+          virtual.option(key as any, newVal[key]);
         }
       }
-    );
+    });
 
-    watch(
-      () => sortableAttributes,
-      (newVal, oldVal) => {
-        if (!virtual) return;
-        for (let key in newVal) {
-          if (newVal[key] != oldVal[key]) {
-            sortable.option(key as any, newVal[key]);
-          }
+    watch(sortableAttributes, (newVal, oldVal) => {
+      if (!virtual) return;
+      for (let key in newVal) {
+        if (newVal[key] != oldVal[key]) {
+          sortable.option(key as any, newVal[key]);
         }
       }
-    );
+    });
 
     // init range
     onBeforeMount(() => {


### PR DESCRIPTION
Hi, thx for your work!
I noticed that some props were not updating when I changed them e.g.
```
const isDisabled = ref(false)
....
//somewhere else
isDisabled.value = true
...
<VirtualDragList :disabled="isDisabled"></VirtualDragList>
```
This change seem to fix reactivity of props. I tested it locally and it works but I didn't tested if some other parts are affected.

Also, when I build it on my local machine there is some change in types file IDK why